### PR TITLE
Add clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/lib/Transform/Affine/AffineFullUnroll.cpp
+++ b/lib/Transform/Affine/AffineFullUnroll.cpp
@@ -10,9 +10,9 @@ using mlir::affine::loopUnrollFull;
 
 void AffineFullUnrollPass::runOnOperation() {
   // getOperation() returns a FuncOp (this pass is registered on a FuncOp)
-  // walk() will walk through all the operations in the function which are AffineForOp
-  // unrolls each AffineForOp
-  // if unrolling fails, emit an error and signal pass failure
+  // walk() will walk through all the operations in the function which are
+  // AffineForOp unrolls each AffineForOp if unrolling fails, emit an error and
+  // signal pass failure
   getOperation().walk([&](AffineForOp op) {
     if (failed(loopUnrollFull(op))) {
       op.emitError("unrolling failed");

--- a/lib/Transform/Affine/AffineFullUnroll.h
+++ b/lib/Transform/Affine/AffineFullUnroll.h
@@ -1,5 +1,5 @@
-#ifndef  LIB_TRANSFORM_AFFINE_AFFINEFULLUNROLL_H_
-#define  LIB_TRANSFORM_AFFINE_AFFINEFULLUNROLL_H_
+#ifndef LIB_TRANSFORM_AFFINE_AFFINEFULLUNROLL_H_
+#define LIB_TRANSFORM_AFFINE_AFFINEFULLUNROLL_H_
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Pass/Pass.h"
@@ -11,13 +11,13 @@ class AffineFullUnrollPass
     : public PassWrapper<AffineFullUnrollPass,
                          OperationPass<mlir::func::FuncOp>> {
 private:
-    void runOnOperation() override;
+  void runOnOperation() override;
 
-    StringRef getArgument() const final { return "affine-full-unroll"; }
+  StringRef getArgument() const final { return "affine-full-unroll"; }
 
-    StringRef getDescription() const final {
-        return "Fully unroll all affine loops";
-    }
+  StringRef getDescription() const final {
+    return "Fully unroll all affine loops";
+  }
 };
 
 } // namespace dummy

--- a/lib/Transform/Arith/MulToAdd.cpp
+++ b/lib/Transform/Arith/MulToAdd.cpp
@@ -10,9 +10,9 @@
 namespace mlir {
 namespace dummy {
 
-using arith::MulIOp;
 using arith::AddIOp;
 using arith::ConstantOp;
+using arith::MulIOp;
 
 // Replace y = C*x with y = C/2*x + C/2*x, when C is a power of 2, otherwise do
 // nothing.
@@ -30,12 +30,12 @@ struct PowerOfTwoExpand : public OpRewritePattern<MulIOp> {
     // canonicalization patterns ensure the constant is on the right, if there
     // is a constant See
     // https://mlir.llvm.org/docs/Canonicalization/#globally-applied-rules
-    
+
     // get the defining operation of the RHS operand, should be a ConstantIntOp
     auto rhsDefiningOp = rhs.getDefiningOp<arith::ConstantIntOp>();
     if (!rhsDefiningOp)
       return failure();
-    
+
     // get the value of the constant
     int64_t rhsValue = rhsDefiningOp.value();
 
@@ -43,7 +43,7 @@ struct PowerOfTwoExpand : public OpRewritePattern<MulIOp> {
 
     if (!is_power_of_two)
       return failure();
-    
+
     // create a new constant with the value of the constant divided by 2
     ConstantOp newConstant = rewriter.create<ConstantOp>(
         rhsDefiningOp.getLoc(),
@@ -69,7 +69,7 @@ struct PeelFromMul : public OpRewritePattern<MulIOp> {
     Value rhs = op.getOperand(1);
     auto rhsDefiningOp = rhs.getDefiningOp<arith::ConstantIntOp>();
     if (!rhsDefiningOp) {
-        return failure();
+      return failure();
     }
 
     int64_t value = rhsDefiningOp.value();

--- a/tools/dummy-opt.cpp
+++ b/tools/dummy-opt.cpp
@@ -7,13 +7,12 @@
 #include "lib/Transform/Arith/MulToAdd.h"
 
 int main(int argc, char **argv) {
-    mlir::DialectRegistry registry;
-    mlir::registerAllDialects(registry);
+  mlir::DialectRegistry registry;
+  mlir::registerAllDialects(registry);
 
-    mlir::PassRegistration<mlir::dummy::AffineFullUnrollPass>();
-    mlir::PassRegistration<mlir::dummy::MulToAddPass>();
+  mlir::PassRegistration<mlir::dummy::AffineFullUnrollPass>();
+  mlir::PassRegistration<mlir::dummy::MulToAddPass>();
 
-    return mlir::asMainReturnCode(
-        mlir::MlirOptMain(argc, argv, "Dummy Pass Driver", registry)
-    );
+  return mlir::asMainReturnCode(
+      mlir::MlirOptMain(argc, argv, "Dummy Pass Driver", registry));
 }


### PR DESCRIPTION
- Added `.clang-format`
- Initially can format code using: `find . -regex '.*\.\(cpp\|h\|hpp\)' -exec clang-format -i {} +`
- In subsequent PRs, use `git clang-format HEAD~1`