### PR TITLE
Traits

### DIFF
--- a/lib/Dialect/Poly10x/Poly10xOps.h
+++ b/lib/Dialect/Poly10x/Poly10xOps.h
@@ -3,9 +3,10 @@
 
 #include "lib/Dialect/Poly10x/Poly10xDialect.h"
 #include "lib/Dialect/Poly10x/Poly10xTypes.h"
-// #include "mlir/include/mlir/IR/BuiltinOps.h"
-// #include "mlir/include/mlir/IR/BuiltinTypes.h"
-// #include "mlir/include/mlir/IR/Dialect.h"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
 
 #define GET_OP_CLASSES
 #include "lib/Dialect/Poly10x/Poly10xOps.h.inc"

--- a/lib/Dialect/Poly10x/Poly10xOps.td
+++ b/lib/Dialect/Poly10x/Poly10xOps.td
@@ -24,7 +24,7 @@ def Poly10x_MulOp : Poly10x_BinOp<"mul"> {
   let summary = "Subtraction operation between polynomials.";
 }
 
-def Poly10x_FromTensorOp : Op<Poly10x_Dialect, "from_tensor"> {
+def Poly10x_FromTensorOp : Op<Poly10x_Dialect, "from_tensor", [Pure]> {
   let summary = "Creates a Polynomial from integer coefficients stored in a tensor.";
   let arguments = (ins TensorOf<[AnyInteger]>:$input);
   let results = (outs Polynomial:$output);

--- a/lib/Dialect/Poly10x/Poly10xOps.td
+++ b/lib/Dialect/Poly10x/Poly10xOps.td
@@ -6,9 +6,13 @@ include "Poly10xTypes.td"
 
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
-class Poly10x_BinOp<string mnemonic> : Op<Poly10x_Dialect, mnemonic, [Pure]> {
-  let arguments = (ins Polynomial:$lhs, Polynomial:$rhs);
-  let results = (outs Polynomial:$output);
+// Type constraint for poly binop arguments: polys, vectors of polys, or
+// tensors of polys.
+def PolyOrContainer : TypeOrValueSemanticsContainer<Polynomial, "poly-or-container">;
+
+class Poly10x_BinOp<string mnemonic> : Op<Poly10x_Dialect, mnemonic, [Pure, ElementwiseMappable]> {
+  let arguments = (ins PolyOrContainer:$lhs, PolyOrContainer:$rhs);
+  let results = (outs PolyOrContainer:$output);
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` `(` type($lhs) `,` type($rhs) `)` `->` type($output)";
 }
 

--- a/lib/Dialect/Poly10x/Poly10xOps.td
+++ b/lib/Dialect/Poly10x/Poly10xOps.td
@@ -10,7 +10,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 // tensors of polys.
 def PolyOrContainer : TypeOrValueSemanticsContainer<Polynomial, "poly-or-container">;
 
-class Poly10x_BinOp<string mnemonic> : Op<Poly10x_Dialect, mnemonic, [Pure, ElementwiseMappable]> {
+class Poly10x_BinOp<string mnemonic> : Op<Poly10x_Dialect, mnemonic, [Pure, ElementwiseMappable, SameOperandsAndResultElementType]> {
   let arguments = (ins PolyOrContainer:$lhs, PolyOrContainer:$rhs);
   let results = (outs PolyOrContainer:$output);
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` `(` type($lhs) `,` type($rhs) `)` `->` type($output)";

--- a/lib/Dialect/Poly10x/Poly10xOps.td
+++ b/lib/Dialect/Poly10x/Poly10xOps.td
@@ -4,7 +4,9 @@
 include "Poly10x.td"
 include "Poly10xTypes.td"
 
-class Poly10x_BinOp<string mnemonic> : Op<Poly10x_Dialect, mnemonic> {
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+class Poly10x_BinOp<string mnemonic> : Op<Poly10x_Dialect, mnemonic, [Pure]> {
   let arguments = (ins Polynomial:$lhs, Polynomial:$rhs);
   let results = (outs Polynomial:$output);
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` `(` type($lhs) `,` type($rhs) `)` `->` type($output)";

--- a/tests/affine_full_unroll.mlir
+++ b/tests/affine_full_unroll.mlir
@@ -2,7 +2,7 @@
 // RUN: FileCheck %s < %t
 
 module {
-  // CHECK-LABEL: @test_single_nested_loop
+  // CHECK-LABEL: test_single_nested_loop
   func.func @test_single_nested_loop(%buffer: memref<4xi32>) -> (i32) {
     %sum_0 = arith.constant 0 : i32
     // CHECK-NOT: affine.for
@@ -14,7 +14,7 @@ module {
     return %sum : i32
   }
 
-  // CHECK-LABEL: @test_doubly_nested_loop
+  // CHECK-LABEL: test_doubly_nested_loop
   func.func @test_doubly_nested_loop(%buffer: memref<4x3xi32>) -> (i32) {
       %sum_0 = arith.constant 0 : i32
       // CHECK-NOT: affine.for

--- a/tests/control_flow_sink.mlir
+++ b/tests/control_flow_sink.mlir
@@ -1,0 +1,24 @@
+// RUN: dummy-opt -control-flow-sink %s | FileCheck %s
+
+// Test that operations can be sunk.
+
+// CHECK-LABEL: test_simple_sink
+func.func @test_simple_sink(%arg0: i1) -> !poly10x.poly<10> {
+    %0 = arith.constant dense<[1, 2, 3]> : tensor<3xi32>
+    %p0 = poly10x.from_tensor %0 : tensor<3xi32> -> !poly10x.poly<10>
+    %1 = arith.constant dense<[9, 8, 16]> : tensor<3xi32>
+    %p1 = poly10x.from_tensor %1 : tensor<3xi32> -> !poly10x.poly<10>
+    // CHECK-NOT: poly10x.from_tensor
+    // CHECK: scf.if
+    %4 = scf.if %arg0 -> (!poly10x.poly<10>) {
+        // CHECK: poly10x.from_tensor
+        %2 = poly10x.mul %p0, %p0 : (!poly10x.poly<10>, !poly10x.poly<10>) -> !poly10x.poly<10>
+        scf.yield %2 : !poly10x.poly<10>
+        // CHECK: else
+    } else {
+        // CHECK: poly10x.from_tensor
+        %3 = poly10x.mul %p1, %p1 : (!poly10x.poly<10>, !poly10x.poly<10>) -> !poly10x.poly<10>
+        scf.yield %3 : !poly10x.poly<10>
+    }
+    return %4 : !poly10x.poly<10>
+}

--- a/tests/licm.mlir
+++ b/tests/licm.mlir
@@ -1,0 +1,25 @@
+// RUN: dummy-opt %s --loop-invariant-code-motion > %t
+// RUN: FileCheck %s < %t
+
+module {
+  // CHECK-LABEL: test_loop_invariant_code_motion
+  func.func @test_loop_invariant_code_motion() -> !poly10x.poly<10> {
+    %0 = arith.constant dense<[1, 2, 3]> : tensor<3xi32>
+    %p0 = poly10x.from_tensor %0 : tensor<3xi32> -> !poly10x.poly<10>
+
+    %1 = arith.constant dense<[9, 8, 16]> : tensor<3xi32>
+    %p1 = poly10x.from_tensor %1 : tensor<3xi32> -> !poly10x.poly<10>
+    // CHECK: poly10x.mul
+
+    // CHECK: affine.for
+    %ret_val = affine.for %i = 0 to 100 iter_args(%sum_iter = %p0) -> !poly10x.poly<10> {
+      // The poly10x.mul should be hoisted out of the loop.
+      // CHECK-NOT: poly10x.mul
+      %2 = poly10x.mul %p0, %p1 : (!poly10x.poly<10>, !poly10x.poly<10>) -> !poly10x.poly<10>
+      %sum_next = poly10x.add %sum_iter, %2 : (!poly10x.poly<10>, !poly10x.poly<10>) -> !poly10x.poly<10>
+      affine.yield %sum_next : !poly10x.poly<10>
+    }
+
+    return %ret_val : !poly10x.poly<10>
+  }
+}

--- a/tests/poly10x_syntax.mlir
+++ b/tests/poly10x_syntax.mlir
@@ -24,8 +24,14 @@ module {
         %4 = poly10x.from_tensor %3 : tensor<3xi32> -> !poly10x.poly<10>
 
         %5 = arith.constant 7 : i32
+
         // CHECK: poly10x.eval
         %6 = poly10x.eval %4, %5 : (!poly10x.poly<10>, i32) -> i32
+
+        %7 = tensor.from_elements %arg0, %arg1 : tensor<2x!poly10x.poly<10>>
+        
+        // CHECK: poly10x.add
+        %8 = poly10x.add %7, %7 : (tensor<2x!poly10x.poly<10>>, tensor<2x!poly10x.poly<10>>) -> tensor<2x!poly10x.poly<10>>
 
         return %4 : !poly10x.poly<10>
     }

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,9 +1,11 @@
 # The MLIR_DIALECT_LIBS property was set in MLIRConfig.cmake file
 # This retrieves the value of the property and stores it in dialect_libs variable
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
 set (LIBS
     ${dialect_libs}
+    ${conversion_libs}
     MLIRPoly10x
     AffineFullUnroll
     MulToAdd

--- a/tools/dummy-opt.cpp
+++ b/tools/dummy-opt.cpp
@@ -1,5 +1,6 @@
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/InitAllDialects.h"
+#include "mlir/InitAllPasses.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 
@@ -13,6 +14,8 @@ int main(int argc, char **argv) {
 
     // register all MLIR dialects
     mlir::registerAllDialects(registry);
+    // register all MLIR passes
+    mlir::registerAllPasses();
     // registering our Poly10xDialect into dummy-opt
     registry.insert<mlir::dummy::poly10x::Poly10xDialect>();
 


### PR DESCRIPTION
- Fixed the includes inside `Poly10xOps.h`
- Added Pure Trait to `Poly10x::BinOp`
- Added `loop-variant-code-motion` test
- Added `CONVERSION_LIBS` property to `tools/CMakeLists.txt` for Traits
- Added `control-flow-sink.mlir` test for testing `Pure` trait of `Poly10x::FromTensorOp`
- Made `affine_full_unroll.mlir` test's labels consistent with other tests
- Added `ElementwiseMappable` Trait to `Poly10x::BinOp`
- Added `TypeOrValueSemanticsContainer`, which is same as `TypeOrContainer` (removed in recent [commit](https://github.com/llvm/llvm-project/pull/126075#issue-2835708384) of llvm-project)
- Added `SameOperandsAndResultElementType` Trait to `Poly10x::BinOp` to make sure operands are of same type/degree