### PR TITLE
Folders

### DIFF
--- a/lib/Dialect/Poly10x/CMakeLists.txt
+++ b/lib/Dialect/Poly10x/CMakeLists.txt
@@ -14,6 +14,7 @@ add_mlir_doc(Poly10x Poly10x Poly10x/ -gen-dialect-doc)
 
 add_mlir_dialect_library(MLIRPoly10x
     Poly10xDialect.cpp
+    Poly10xOps.cpp
 
     ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/lib/Dialect/Poly10x

--- a/lib/Dialect/Poly10x/Poly10x.td
+++ b/lib/Dialect/Poly10x/Poly10x.td
@@ -13,6 +13,7 @@ def Poly10x_Dialect : Dialect {
     let cppNamespace = "::mlir::dummy::poly10x";
 
     let useDefaultTypePrinterParser = 1;
+    let hasConstantMaterializer = 1;
 }
 
 #endif  // LIB_DIALECT_POLY_POLY10XDIALECT_TD_

--- a/lib/Dialect/Poly10x/Poly10xDialect.cpp
+++ b/lib/Dialect/Poly10x/Poly10xDialect.cpp
@@ -29,6 +29,13 @@ void Poly10xDialect::initialize() {
         >();
 }
 
+Operation *Poly10xDialect::materializeConstant(OpBuilder &builder, Attribute value, Type type, Location loc) {
+    auto coefficients = dyn_cast<DenseIntElementsAttr>(value);
+    if (!coefficients)
+        return nullptr;
+    return builder.create<ConstantOp>(loc, type, coefficients);
+}
+
 } // namespace poly10x
 } // namespace dummy
 } // namespace mlir

--- a/lib/Dialect/Poly10x/Poly10xDialect.cpp
+++ b/lib/Dialect/Poly10x/Poly10xDialect.cpp
@@ -29,7 +29,9 @@ void Poly10xDialect::initialize() {
         >();
 }
 
-Operation *Poly10xDialect::materializeConstant(OpBuilder &builder, Attribute value, Type type, Location loc) {
+Operation *Poly10xDialect::materializeConstant(OpBuilder &builder,
+                                               Attribute value, Type type,
+                                               Location loc) {
     auto coefficients = dyn_cast<DenseIntElementsAttr>(value);
     if (!coefficients)
         return nullptr;

--- a/lib/Dialect/Poly10x/Poly10xOps.cpp
+++ b/lib/Dialect/Poly10x/Poly10xOps.cpp
@@ -1,0 +1,13 @@
+#include "lib/Dialect/Poly10x/Poly10xOps.h"
+
+namespace mlir {
+namespace dummy {
+namespace poly10x {
+
+OpFoldResult ConstantOp::fold(ConstantOp::FoldAdaptor adaptor) {
+  return adaptor.getCoefficients();
+}
+
+}  // namespace poly
+}  // namespace tutorial
+}  // namespace mlir

--- a/lib/Dialect/Poly10x/Poly10xOps.cpp
+++ b/lib/Dialect/Poly10x/Poly10xOps.cpp
@@ -5,9 +5,9 @@ namespace dummy {
 namespace poly10x {
 
 OpFoldResult ConstantOp::fold(ConstantOp::FoldAdaptor adaptor) {
-  return adaptor.getCoefficients();
+    return adaptor.getCoefficients();
 }
 
-}  // namespace poly
-}  // namespace tutorial
-}  // namespace mlir
+} // namespace poly10x
+} // namespace dummy
+} // namespace mlir

--- a/lib/Dialect/Poly10x/Poly10xOps.cpp
+++ b/lib/Dialect/Poly10x/Poly10xOps.cpp
@@ -1,11 +1,66 @@
 #include "lib/Dialect/Poly10x/Poly10xOps.h"
+#include "lib/Dialect/Poly10x/Poly10xTypes.h"
+#include "mlir/Dialect/CommonFolders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/OpDefinition.h"
+#include "llvm/ADT/APInt.h"
 
 namespace mlir {
 namespace dummy {
 namespace poly10x {
 
+using llvm::APInt;
+
 OpFoldResult ConstantOp::fold(ConstantOp::FoldAdaptor adaptor) {
     return adaptor.getCoefficients();
+}
+
+OpFoldResult AddOp::fold(AddOp::FoldAdaptor adaptor) {
+  return constFoldBinaryOp<IntegerAttr, APInt, void>(adaptor.getOperands(), [&](APInt a, APInt b) {return a + b;});
+}
+
+OpFoldResult SubOp::fold(SubOp::FoldAdaptor adaptor) {
+  return constFoldBinaryOp<IntegerAttr, APInt, void>(adaptor.getOperands(), [&](APInt a, APInt b) {return a - b;});
+}
+
+OpFoldResult MulOp::fold(MulOp::FoldAdaptor adaptor) {
+  auto lhs = dyn_cast<DenseElementsAttr>(adaptor.getOperands()[0]);
+  auto rhs = dyn_cast<DenseElementsAttr>(adaptor.getOperands()[1]);
+
+  if (!lhs || !rhs) {
+    return nullptr;
+  }
+
+  auto degree = cast<PolynomialType>(getResult().getType()).getDegreeBound();
+  auto maxIndex = lhs.size() + rhs.size() - 1;
+
+  SmallVector<APInt, 8> result;
+  result.reserve(maxIndex);
+
+  for (int i = 0; i < maxIndex; ++i) {
+    result.push_back(APInt(lhs.getType().getElementType().getIntOrFloatBitWidth(), 0));
+  }
+  
+  int i = 0;
+  for (auto lhsIt = lhs.value_begin<APInt>(); lhsIt != lhs.value_end<APInt>();
+       ++lhsIt) {
+    int j = 0;
+    for (auto rhsIt = rhs.value_begin<APInt>(); rhsIt != rhs.value_end<APInt>();
+         ++rhsIt) {
+      result[(i + j) % degree] += *rhsIt * (*lhsIt);
+      ++j;
+    }
+    ++i;
+  }
+  return DenseIntElementsAttr::get(
+    RankedTensorType::get(static_cast<int64_t>(result.size()),
+                          IntegerType::get(getContext(), 32)),
+    result);
+}
+
+OpFoldResult FromTensorOp::fold(FromTensorOp::FoldAdaptor adaptor) {
+  // Returns null if the cast failed, which corresponds to a failed fold.
+  return dyn_cast<DenseIntElementsAttr>(adaptor.getInput());
 }
 
 } // namespace poly10x

--- a/lib/Dialect/Poly10x/Poly10xOps.cpp
+++ b/lib/Dialect/Poly10x/Poly10xOps.cpp
@@ -16,51 +16,54 @@ OpFoldResult ConstantOp::fold(ConstantOp::FoldAdaptor adaptor) {
 }
 
 OpFoldResult AddOp::fold(AddOp::FoldAdaptor adaptor) {
-  return constFoldBinaryOp<IntegerAttr, APInt, void>(adaptor.getOperands(), [&](APInt a, APInt b) {return a + b;});
+    return constFoldBinaryOp<IntegerAttr, APInt, void>(
+        adaptor.getOperands(), [&](APInt a, APInt b) { return a + b; });
 }
 
 OpFoldResult SubOp::fold(SubOp::FoldAdaptor adaptor) {
-  return constFoldBinaryOp<IntegerAttr, APInt, void>(adaptor.getOperands(), [&](APInt a, APInt b) {return a - b;});
+    return constFoldBinaryOp<IntegerAttr, APInt, void>(
+        adaptor.getOperands(), [&](APInt a, APInt b) { return a - b; });
 }
 
 OpFoldResult MulOp::fold(MulOp::FoldAdaptor adaptor) {
-  auto lhs = dyn_cast<DenseElementsAttr>(adaptor.getOperands()[0]);
-  auto rhs = dyn_cast<DenseElementsAttr>(adaptor.getOperands()[1]);
+    auto lhs = dyn_cast<DenseElementsAttr>(adaptor.getOperands()[0]);
+    auto rhs = dyn_cast<DenseElementsAttr>(adaptor.getOperands()[1]);
 
-  if (!lhs || !rhs) {
-    return nullptr;
-  }
-
-  auto degree = cast<PolynomialType>(getResult().getType()).getDegreeBound();
-  auto maxIndex = lhs.size() + rhs.size() - 1;
-
-  SmallVector<APInt, 8> result;
-  result.reserve(maxIndex);
-
-  for (int i = 0; i < maxIndex; ++i) {
-    result.push_back(APInt(lhs.getType().getElementType().getIntOrFloatBitWidth(), 0));
-  }
-  
-  int i = 0;
-  for (auto lhsIt = lhs.value_begin<APInt>(); lhsIt != lhs.value_end<APInt>();
-       ++lhsIt) {
-    int j = 0;
-    for (auto rhsIt = rhs.value_begin<APInt>(); rhsIt != rhs.value_end<APInt>();
-         ++rhsIt) {
-      result[(i + j) % degree] += *rhsIt * (*lhsIt);
-      ++j;
+    if (!lhs || !rhs) {
+        return nullptr;
     }
-    ++i;
-  }
-  return DenseIntElementsAttr::get(
-    RankedTensorType::get(static_cast<int64_t>(result.size()),
-                          IntegerType::get(getContext(), 32)),
-    result);
+
+    auto degree = cast<PolynomialType>(getResult().getType()).getDegreeBound();
+    auto maxIndex = lhs.size() + rhs.size() - 1;
+
+    SmallVector<APInt, 8> result;
+    result.reserve(maxIndex);
+
+    for (int i = 0; i < maxIndex; ++i) {
+        result.push_back(
+            APInt(lhs.getType().getElementType().getIntOrFloatBitWidth(), 0));
+    }
+
+    int i = 0;
+    for (auto lhsIt = lhs.value_begin<APInt>(); lhsIt != lhs.value_end<APInt>();
+         ++lhsIt) {
+        int j = 0;
+        for (auto rhsIt = rhs.value_begin<APInt>();
+             rhsIt != rhs.value_end<APInt>(); ++rhsIt) {
+            result[(i + j) % degree] += *rhsIt * (*lhsIt);
+            ++j;
+        }
+        ++i;
+    }
+    return DenseIntElementsAttr::get(
+        RankedTensorType::get(static_cast<int64_t>(result.size()),
+                              IntegerType::get(getContext(), 32)),
+        result);
 }
 
 OpFoldResult FromTensorOp::fold(FromTensorOp::FoldAdaptor adaptor) {
-  // Returns null if the cast failed, which corresponds to a failed fold.
-  return dyn_cast<DenseIntElementsAttr>(adaptor.getInput());
+    // Returns null if the cast failed, which corresponds to a failed fold.
+    return dyn_cast<DenseIntElementsAttr>(adaptor.getInput());
 }
 
 } // namespace poly10x

--- a/lib/Dialect/Poly10x/Poly10xOps.td
+++ b/lib/Dialect/Poly10x/Poly10xOps.td
@@ -22,6 +22,7 @@ class Poly10x_BinOp<string mnemonic> : Op<Poly10x_Dialect, mnemonic, [Pure, Elem
   let arguments = (ins PolyOrContainer:$lhs, PolyOrContainer:$rhs);
   let results = (outs PolyOrContainer:$output);
   let assemblyFormat = "$lhs `,` $rhs attr-dict `:` `(` type($lhs) `,` type($rhs) `)` `->` type($output)";
+  let hasFolder = 1;
 }
 
 def Poly10x_AddOp : Poly10x_BinOp<"add"> {
@@ -41,6 +42,7 @@ def Poly10x_FromTensorOp : Op<Poly10x_Dialect, "from_tensor", [Pure]> {
   let arguments = (ins TensorOf<[AnyInteger]>:$input);
   let results = (outs Polynomial:$output);
   let assemblyFormat = "$input attr-dict `:` type($input) `->` type($output)";
+  let hasFolder = 1;
 }
 
 def Poly10x_EvalOp : Op<Poly10x_Dialect, "eval"> {

--- a/lib/Dialect/Poly10x/Poly10xOps.td
+++ b/lib/Dialect/Poly10x/Poly10xOps.td
@@ -6,6 +6,13 @@ include "Poly10xTypes.td"
 
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
+def Poly10x_ConstantOp : Op<Poly10x_Dialect, "constant", [Pure, ConstantLike]> {
+  let summary = "Define a constant polynomial via an attribute.";
+  let arguments = (ins AnyIntElementsAttr:$coefficients);
+  let results = (outs Polynomial:$output);
+  let assemblyFormat = "$coefficients attr-dict `:` type($output)";
+}
+
 // Type constraint for poly binop arguments: polys, vectors of polys, or
 // tensors of polys.
 def PolyOrContainer : TypeOrValueSemanticsContainer<Polynomial, "poly-or-container">;

--- a/lib/Dialect/Poly10x/Poly10xOps.td
+++ b/lib/Dialect/Poly10x/Poly10xOps.td
@@ -11,9 +11,10 @@ def Poly10x_ConstantOp : Op<Poly10x_Dialect, "constant", [Pure, ConstantLike]> {
   let arguments = (ins AnyIntElementsAttr:$coefficients);
   let results = (outs Polynomial:$output);
   let assemblyFormat = "$coefficients attr-dict `:` type($output)";
+  let hasFolder = 1;
 }
 
-// Type constraint for poly binop arguments: polys, vectors of polys, or
+// Type constraint for poly10x binop arguments: polys, vectors of polys, or
 // tensors of polys.
 def PolyOrContainer : TypeOrValueSemanticsContainer<Polynomial, "poly-or-container">;
 

--- a/tests/poly10x_canonicalize.mlir
+++ b/tests/poly10x_canonicalize.mlir
@@ -1,0 +1,13 @@
+// RUN: dummy-opt --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: test_simple
+func.func @test_simple() -> !poly10x.poly<10> {
+  // CHECK: poly10x.constant dense<[2, 4, 6]>
+  // CHECK-NEXT: return
+  %0 = arith.constant dense<[1, 2, 3]> : tensor<3xi32>
+  %p0 = poly10x.from_tensor %0 : tensor<3xi32> -> !poly10x.poly<10>
+  %2 = poly10x.add %p0, %p0 : (!poly10x.poly<10>, !poly10x.poly<10>) -> !poly10x.poly<10>
+  %3 = poly10x.mul %p0, %p0 : (!poly10x.poly<10>, !poly10x.poly<10>) -> !poly10x.poly<10>
+  %4 = poly10x.add %2, %3 : (!poly10x.poly<10>, !poly10x.poly<10>) -> !poly10x.poly<10>
+  return %2 : !poly10x.poly<10>
+}

--- a/tests/poly10x_syntax.mlir
+++ b/tests/poly10x_syntax.mlir
@@ -33,6 +33,12 @@ module {
         // CHECK: poly10x.add
         %8 = poly10x.add %7, %7 : (tensor<2x!poly10x.poly<10>>, tensor<2x!poly10x.poly<10>>) -> tensor<2x!poly10x.poly<10>>
 
+        // CHECK: poly10x.constant
+        %10 = poly10x.constant dense<[2, 3, 4]> : tensor<3xi32> : !poly10x.poly<10>
+        %11 = poly10x.constant dense<[2, 3, 4]> : tensor<3xi8> : !poly10x.poly<10>
+        %12 = poly10x.constant dense<"0x020304"> : tensor<3xi8> : !poly10x.poly<10>
+        %13 = poly10x.constant dense<4> : tensor<100xi32> : !poly10x.poly<10>
+
         return %4 : !poly10x.poly<10>
     }
 }

--- a/tests/sccp.mlir
+++ b/tests/sccp.mlir
@@ -3,7 +3,7 @@
 // Note how sscp creates new constants for the computed values,
 // though it does not remove the dead code.
 
-// CHECK-LABEL: @test_arith_sccp
+// CHECK-LABEL: test_arith_sccp
 // CHECK-NEXT: %[[v0:.*]] = arith.constant 63 : i32
 // CHECK-NEXT: %[[v1:.*]] = arith.constant 49 : i32
 // CHECK-NEXT: %[[v2:.*]] = arith.constant 14 : i32
@@ -19,7 +19,7 @@ func.func @test_arith_sccp() -> i32 {
   return %2 : i32
 }
 
-// CHECK-LABEL: @test_poly_sccp
+// CHECK-LABEL: test_poly_sccp
 func.func @test_poly_sccp() -> !poly10x.poly<10> {
   %0 = arith.constant dense<[1, 2, 3]> : tensor<3xi32>
   %p0 = poly10x.from_tensor %0 : tensor<3xi32> -> !poly10x.poly<10>

--- a/tests/sccp.mlir
+++ b/tests/sccp.mlir
@@ -1,0 +1,35 @@
+// RUN: dummy-opt -pass-pipeline="builtin.module(func.func(sccp))" %s | FileCheck %s
+
+// Note how sscp creates new constants for the computed values,
+// though it does not remove the dead code.
+
+// CHECK-LABEL: @test_arith_sccp
+// CHECK-NEXT: %[[v0:.*]] = arith.constant 63 : i32
+// CHECK-NEXT: %[[v1:.*]] = arith.constant 49 : i32
+// CHECK-NEXT: %[[v2:.*]] = arith.constant 14 : i32
+// CHECK-NEXT: %[[v3:.*]] = arith.constant 8 : i32
+// CHECK-NEXT: %[[v4:.*]] = arith.constant 7 : i32
+// CHECK-NEXT: return %[[v2]] : i32
+func.func @test_arith_sccp() -> i32 {
+  %0 = arith.constant 7 : i32
+  %1 = arith.constant 8 : i32
+  %2 = arith.addi %0, %0 : i32
+  %3 = arith.muli %0, %0 : i32
+  %4 = arith.addi %2, %3 : i32
+  return %2 : i32
+}
+
+// CHECK-LABEL: @test_poly_sccp
+func.func @test_poly_sccp() -> !poly10x.poly<10> {
+  %0 = arith.constant dense<[1, 2, 3]> : tensor<3xi32>
+  %p0 = poly10x.from_tensor %0 : tensor<3xi32> -> !poly10x.poly<10>
+  // CHECK: poly10x.constant dense<[2, 8, 20, 24, 18]>
+  // CHECK: poly10x.constant dense<[1, 4, 10, 12, 9]>
+  // CHECK: poly10x.constant dense<[1, 2, 3]>
+  // CHECK-NOT: poly10x.mul
+  // CHECK-NOT: poly10x.add
+  %2 = poly10x.mul %p0, %p0 : (!poly10x.poly<10>, !poly10x.poly<10>) -> !poly10x.poly<10>
+  %3 = poly10x.mul %p0, %p0 : (!poly10x.poly<10>, !poly10x.poly<10>) -> !poly10x.poly<10>
+  %4 = poly10x.add %2, %3 : (!poly10x.poly<10>, !poly10x.poly<10>) -> !poly10x.poly<10>
+  return %2 : !poly10x.poly<10>
+}


### PR DESCRIPTION
- The MLIR documentation on [folding](https://mlir.llvm.org/docs/Canonicalization/#canonicalizing-with-the-fold-method) is pretty good and easy to understand so one can look that up to fully understand how folding and this PR works.
- `sccp` works in this way: Gets the `Op`  ---> Calls the fold operation of given `Op` ---> Creates a `ConstantOp` for that Dialect ---> Replaces all uses of that `Op` with that `ConstantOp`
- Added Canonicalize and Sparse Conditional Constant Propagation test cases
- Added `poly10x::ConstantOp`
- Added folder for `poly10x::ConstantOp`
- Added folders for `poly10x::AddOp`, `poly10x::SubOp`, and `poly10x::MulOP`
- Added folder for `poly10x::FromTensorOp`