### PR TITLE
Add conversion pattern for `Poly10x::MulOp`

### DIFF
--- a/lib/Conversion/Poly10xToStandard/Poly10xToStandard.td
+++ b/lib/Conversion/Poly10xToStandard/Poly10xToStandard.td
@@ -14,7 +14,8 @@ def Poly10xToStandard : Pass<"poly10x-to-standard"> {
     let dependentDialects = [
         "mlir::arith::ArithDialect",
         "mlir::dummy::poly10x::Poly10xDialect",
-        "mlir::tensor::TensorDialect"
+        "mlir::tensor::TensorDialect",
+        "mlir::scf::SCFDialect",
     ];
 }
 

--- a/tests/poly10x_to_standard.mlir
+++ b/tests/poly10x_to_standard.mlir
@@ -38,3 +38,30 @@ func.func @test_lower_to_tensor(%0: !poly10x.poly<10>) -> tensor<10xi32> {
   %2 = poly10x.to_tensor %0: !poly10x.poly<10> -> tensor<10xi32>
   return %2 : tensor<10xi32>
 }
+
+// CHECK-LABEL: test_lower_mul
+// CHECK-SAME:  (%[[p0:.*]]: [[T:tensor<10xi32>]], %[[p1:.*]]: [[T]]) -> [[T]] {
+// CHECK:    %[[cst:.*]] = arith.constant dense<0> : [[T]]
+// CHECK:    %[[c0:.*]] = arith.constant 0 : index
+// CHECK:    %[[c10:.*]] = arith.constant 10 : index
+// CHECK:    %[[c1:.*]] = arith.constant 1 : index
+// CHECK:    %[[outer:.*]] = scf.for %[[outer_iv:.*]] = %[[c0]] to %[[c10]] step %[[c1]] iter_args(%[[outer_iter_arg:.*]] = %[[cst]]) -> ([[T]]) {
+// CHECK:      %[[inner:.*]] = scf.for %[[inner_iv:.*]] = %[[c0]] to %[[c10]] step %[[c1]] iter_args(%[[inner_iter_arg:.*]] = %[[outer_iter_arg]]) -> ([[T]]) {
+// CHECK:        %[[index_sum:.*]] = arith.addi %arg2, %arg4
+// CHECK:        %[[dest_index:.*]] = arith.remui %[[index_sum]], %[[c10]]
+// CHECK-DAG:    %[[p0_extracted:.*]] = tensor.extract %[[p0]][%[[outer_iv]]]
+// CHECK-DAG:    %[[p1_extracted:.*]] = tensor.extract %[[p1]][%[[inner_iv]]]
+// CHECK:        %[[coeff_mul:.*]] = arith.muli %[[p0_extracted]], %[[p1_extracted]]
+// CHECK:        %[[accum:.*]] = tensor.extract %[[inner_iter_arg]][%[[dest_index]]]
+// CHECK:        %[[to_insert:.*]] = arith.addi %[[coeff_mul]], %[[accum]]
+// CHECK:        %[[inserted:.*]] = tensor.insert %[[to_insert]] into %[[inner_iter_arg]][%[[dest_index]]]
+// CHECK:        scf.yield %[[inserted]]
+// CHECK:      }
+// CHECK:      scf.yield %[[inner]]
+// CHECK:    }
+// CHECK:    return %[[outer]]
+// CHECK:  }
+func.func @test_lower_mul(%0 : !poly10x.poly<10>, %1 : !poly10x.poly<10>) -> !poly10x.poly<10> {
+  %2 = poly10x.mul %0, %1 : (!poly10x.poly<10>, !poly10x.poly<10>) -> !poly10x.poly<10>
+  return %2 : !poly10x.poly<10>
+}


### PR DESCRIPTION
Useful for seeing how `scf::forOp` gets inserted in MLIR.
Copied directly from [mlir-tutorial](https://github.com/j2kun/mlir-tutorial)