### PR TITLE
Update tools CMake

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -13,6 +13,8 @@ set (LIBS
     MLIROptLib
     MLIRPass
     MLIRPoly10xToStandard
+    MLIRRegisterAllDialects
+    MLIRRegisterAllPasses
 )
 
 # Macro defined in AddLLVM.cmake file


### PR DESCRIPTION
This change is needed because upstream MLIR now requries adding `MLIRRegisterAllDialects` and `MLIRRegisterAllPasses` as libraries to the compilation of tools like opt. The corresponding PR is [https://github.com/llvm/llvm-project/pull/151183](https://github.com/llvm/llvm-project/pull/151183).